### PR TITLE
Fix weasyprint 54.1 report issue

### DIFF
--- a/report/report.css
+++ b/report/report.css
@@ -104,12 +104,15 @@ h3 {
 h4 {
   font-size: 13pt;
 }
-
-#cover {
+#cover .addresses {
+  position: absolute;
+  bottom: 0;
+  left:0;
+  right: 0;
+  height: auto;
   align-content: space-between;
   display: flex;
   flex-wrap: wrap;
-  height: 297mm;
 }
 #cover address {
   background: #fbc847;

--- a/report/report.html
+++ b/report/report.html
@@ -9,15 +9,17 @@
   <body>
     <article id="cover">
       <h1>Report example</h1>
-      <address>
-        WeasyPrint
-        26 rue Emile Decorps
-        69100 Villeurbanne France
-      </address>
-      <address>
-        contact@courtbouillon.org
-        https://courtbouillon.org
-      </address>
+      <div class="addresses">
+        <address>
+          WeasyPrint
+          26 rue Emile Decorps
+          69100 Villeurbanne France
+        </address>
+        <address>
+          contact@courtbouillon.org
+          https://courtbouillon.org
+        </address>
+      </div>
     </article>
 
     <article id="contents">


### PR DESCRIPTION
Hi, 

I'm building a weasyprint docker image based on Debian 11 and testing the report example:
* with weasyprint **54.1**:

![weasyprint-report-01](https://user-images.githubusercontent.com/46624375/154816872-65275f03-1f56-48ab-940d-8c3659bbae10.png)

* no issue with the weasyprint  **53.4**

I'm looking the cause of the difference and I find that is a calculation precision issue, with `height: 290mm` there no issue.
```css
#cover {
  align-content: space-between;
  display: flex;
  flex-wrap: wrap;
  height: 297mm;
  height: 290mm;
}
```
So, I propose to change the code a bit to avoid using the height of the page to set the positions of the two `<address>`.

Below the two reports PDF:
* [report.pdf with issue](https://github.com/CourtBouillon/weasyprint-samples/files/8102916/report-54.1.pdf)
* [report.pdf with issue fixed](https://github.com/CourtBouillon/weasyprint-samples/files/8102917/report-54.1-fixed.pdf)
